### PR TITLE
Add missing README build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The cryptography behind is provided by *OpenSSL*.
 Building the library and application:
 
     mkdir build
+    cd build
     cmake ..
     make
 


### PR DESCRIPTION
The previous instructions didn't work out of the box.

```txt
$ mkdir build
$ cmake ..
CMake Error: The source directory "/home/erlend/Code" does not appear to contain CMakeLists.txt.
Specify --help for usage, or press the help button on the CMake GUI.
```